### PR TITLE
Add strategic priorities timeline document

### DIFF
--- a/strategic_priorities.md
+++ b/strategic_priorities.md
@@ -1,0 +1,192 @@
+FRAMING FOR ACADEMIC PURSUITS
+
+
+- First experience fully investing in academic pursuits as a student
+- Pattern-matching across industries to drive superior insights and strategic differentiation
+- My trajectory: investment skill-building and experiential learning across roles --> targeted thesis-building, catalyzed by HBS resources and infrastructure
+- What my projects communicate:
+- Case says “I have proprietary, ground-floor insight.”
+- Paper says “I can generalize that insight to wider markets.”
+- Track-record & grades say “I execute with discipline.”
+
+
+RESOURCES
+
+- HBS Independent Projects (IP) Best Practices
+
+
+Summer 2025
+
+
+- Professional goals: 
+- Mar 24 – Secure aligned, part-time work ✅
+- May 19 – Compound reputational leverage on LinkedIn: Admitted & committed: “Officially joining the Harvard Business School Class of 2027. First time I’ll invest full-time in academic discovery...” ✅
+- "My decision to attend HBS is the latest in a line of asymmetric bets I've made in my own professional and personal development... couldn't be more grateful so the support of so many along this journey. In particular, I owe a debt of gratitude to ..."
+- Jun 02 – Author a one-pager "Investment Story and Edge" that distinctly outlines my pedigree for special sits PE and HF, including a comprehensive deal journal and research agenda for HBS
+- Jun 23 – Schedule two informational Zooms with HBS alumni at each of my top five target firms, securing intros by August 1st
+- Jul 07 – Complete a 2-stock / 1-situation mini pitch deck and ask HF contacts for critique  
+- Academic goals:
+- IP1
+- May 19 – Draft 1-page case concept & teaching objective, shortlisting three potential faculty sponsors
+- Jun 02 – Secure "yes-in-principle" from Arctos GC (joint)
+- Jun 16 – Build documents folder; sketch issue tree for case
+- Aug 25 – Send faculty outreach emails
+- IP2
+- May 19 – Write down three possible research themes
+- Jun 09 – Author three literature review memos/research prospectuses on three possible research topics
+- Aug 25 – Send faculty outreach emails
+- CFA
+- Aug 25 – Pass CFA Level 2
+- Tips: 
+- Professional
+- Show professionals that you’re wrestling with questions (“Why does permanent capital trade at X discount?”) rather than listing activities. In networking emails, always lead with an insight or hypothesis, not a request.
+- After an informational chat, send the contact a “reflection note” on what you learned and how it shapes your thesis. It positions you as a peer-thinker, not a supplicant.
+- Protections:
+- Protect two 3-hour, early-morning “deep work sessions” (maybe early a.m. Tue / Fri). Never surrender them—IP writing, data work, or deep reading only.
+- Maintain a strict, 5-day workout regimen—essential for intellectual digestion, reflection, stress management, energy regulation, and self-esteem boosting.
+- 90-minute “velocity recovery” block every Sunday. 30 min reflection (WIRTW), 30 min planning, 30 min meditation or walk. Research shows structured recovery boosts working-memory scores—your Cat I secret weapon.
+
+Fall 2025 • Semester 1
+
+
+- Professional goals: 
+- Sep – Submit updated resume and deal journal to target firms
+- Oct – Compound reputational leverage on LinkedIn: CONTINUE HERE
+- Nov – Update "Investment Story and Edge" to add RC "Case Insight Memos" relating class content to targeted investment themes; share collateral with contacts to assess intellectual and practical resonance
+- Academic goals: 
+- IP1
+- Oct – Initiate conversations with shortlisted professors to probe fit (joint)
+- Nov – Produce interview guide with 6–8 execs (joint) 
+- IP2
+- Oct – Select a single theme and assess data availability for the execution of the project; generate one-page concept note
+- Oct – Initiate conversations with shortlisted professors to probe fit 
+- Tips:
+- Professional
+- After an informational chat, send the contact a “reflection note” on what you learned and how it shapes your thesis. It positions you as a peer-thinker, not a supplicant.
+- Write a 150-word distillation after every class. Turns each case into recall fodder before finals and primes you for Category I exam essays. Takes <10 min—small habit, big GPA delta.
+- Academic
+- 10 × I, 20 × II = 1.33 GPA -> 95% likelihood to earn Baker distinction 
+- Enlist professors in crusade to earn Baker Scholar recognition
+- Instead of 30-minute office-hour slots, drop professors a single, well-scoped question by email (takes them < 5 min to answer). Return with an update the next week. It compounds goodwill with near-zero time costs.
+- Show professionals that you’re wrestling with questions (“Why does permanent capital trade at X discount?”) rather than listing activities. In networking emails, always lead with an insight or hypothesis, not a request.
+- Participation portfolio approach. Aim for two high-impact comments per class week. Track them in a spreadsheet (case, date, angle, outcome). Portfolio thinking avoids feast-or-famine comment weeks that jeopardize Cat I odds.
+- Protections:
+- Avoid club leadership. RC and EC grades are critical, and IPs already supply résumé substance.
+- Protect two 3-hour, early-morning “deep work sessions” (maybe early a.m. Tue / Fri). Never surrender them—IP writing, data work, or deep reading only.
+- Maintain a strict, 5-day workout regimen—essential for intellectual digestion, reflection, stress management, energy regulation, and self-esteem boosting.
+- Block Tuesdays 15:30-17:00 and Friday lunch for coffees. Anything outside these windows cannibalizes case prep—non-negotiable if you want 1.33 GPA.
+- 90-minute “velocity recovery” block every Sunday. 30 min reflection (WIRTW), 30 min planning, 30 min meditation or walk. Research shows structured recovery boosts working-memory scores—your Cat I secret weapon.
+
+
+Spring 2026 – Semester 2
+
+
+- Academic goals: 
+- IP1
+- Jan – Generate three-page working outline and timeline for professorial review (joint)
+- Jan – Book initial 3-4 exec interviews, making sure to gather transcripts (joint)
+- Mar – Build a case storyboard
+- Apr – Write a six-page narrative/dead-ends draft
+- IP2
+- Jan – Generate and submit a one-page problem statement to top two candidate faculty sponsors
+- Jan – Conduct a data-access feasibility check
+- Apr – Secure a tentative faculty sponsor
+- Tips:
+- Professional
+- After an informational chat, send the contact a “reflection note” on what you learned and how it shapes your thesis. It positions you as a peer-thinker, not a supplicant.
+- Write a 150-word distillation after every class. Turns each case into recall fodder before finals and primes you for Category I exam essays. Takes <10 min—small habit, big GPA delta.
+- Academic
+- 10 × I, 20 × II = 1.33 GPA -> 95% likelihood to earn Baker distinction 
+- Enlist professors in crusade to earn Baker Scholar recognition
+- Instead of 30-minute office-hour slots, drop professors a single, well-scoped question by email (takes them < 5 min to answer). Return with an update the next week. It compounds goodwill with near-zero time costs.
+- Show professionals that you’re wrestling with questions (“Why does permanent capital trade at X discount?”) rather than listing activities. In networking emails, always lead with an insight or hypothesis, not a request.
+- Participation portfolio approach. Aim for two high-impact comments per class week. Track them in a spreadsheet (case, date, angle, outcome). Portfolio thinking avoids feast-or-famine comment weeks that jeopardize Cat I odds.
+- Protections:
+- Avoid club leadership. RC and EC grades are critical, and IPs already supply résumé substance.
+- Protect two 3-hour, early-morning “deep work sessions” (maybe early a.m. Tue / Fri). Never surrender them—IP writing, data work, or deep reading only.
+- Maintain a strict, 5-day workout regimen—essential for intellectual digestion, reflection, stress management, energy regulation, and self-esteem boosting.
+- Block Tuesdays 15:30-17:00 and Friday lunch for coffees. Anything outside these windows cannibalizes case prep—non-negotiable if you want 1.33 GPA.
+- 90-minute “velocity recovery” block every Sunday. 30 min reflection (WIRTW), 30 min planning, 30 min meditation or walk. Research shows structured recovery boosts working-memory scores—your Cat I secret weapon.
+
+Summer 2026
+
+
+- Academic goals: 
+- CFA
+- Aug – Pass CFA level 3
+- IP1
+- Jun – Complete project exhibits (joint)
+- Jun – Pre-mortem the IP scope: Draft a one-page “How This Could Fail” memo: data gaps, legal releases, calendar creep. Address the top risk up front; the rest usually fall away
+- IP2
+- Jun – Conduct a two-weekend data crunch and write a method memo
+- Jun – Pre-mortem the IP scope: Draft a one-page “How This Could Fail” memo: data gaps, legal releases, calendar creep. Address the top risk up front; the rest usually fall away
+
+
+Fall 2026 – Semester 3
+
+
+- Professional goals: 
+- Sep – Submit updated resume and deal journal to target firms
+- Academic goals:
+- IP1
+- Sep – Register the research project during the add-drop period (joint)
+- Sep – Begin two-a-week three-hour writing sprints, which will last all semester (joint)
+- Sep – Begin meeting schedule with faculty sponsor
+- Nov – Pilot-teach case to five classmates and faculty sponsor as a pilot prior to HBSP submission (joint)
+- IP2
+- Sep – Polish a full proposal draft of the research project
+- Nov – Finalize 3-page proposal
+- Tips: 
+- Professional 
+- Show professionals that you’re wrestling with questions (“Why does permanent capital trade at X discount?”) rather than listing activities. In networking emails, always lead with an insight or hypothesis, not a request.
+- After an informational chat, send the contact a “reflection note” on what you learned and how it shapes your thesis. It positions you as a peer-thinker, not a supplicant.
+- Academic
+- 10 × I, 20 × II = 1.33 GPA -> 95% likelihood to earn Baker distinction 
+- Enlist professors in crusade to earn Baker Scholar recognition
+- Instead of 30-minute office-hour slots, drop professors a single, well-scoped question by email (takes them < 5 min to answer). Return with an update the next week. It compounds goodwill with near-zero time costs.
+- Write a 150-word distillation after every class. Turns each case into recall fodder before finals and primes you for Category I exam essays. Takes <10 min—small habit, big GPA delta.
+- Participation portfolio approach. Aim for two high-impact comments per class week. Track them in a spreadsheet (case, date, angle, outcome). Portfolio thinking avoids feast-or-famine comment weeks that jeopardize Cat I odds.
+- Protections:
+- Avoid club leadership. RC and EC grades are critical, and IPs already supply résumé substance.
+- Protect two 3-hour, early-morning “deep work sessions” (maybe early a.m. Tue / Fri). Never surrender them—IP writing, data work, or deep reading only.
+- Maintain a strict, 5-day workout regimen—essential for intellectual digestion, reflection, stress management, energy regulation, and self-esteem boosting.
+- Block Tuesdays 15:30-17:00 and Friday lunch for coffees. Anything outside these windows cannibalizes case prep—non-negotiable if you want 1.33 GPA.
+- 90-minute “velocity recovery” block every Sunday. 30 min reflection (WIRTW), 30 min planning, 30 min meditation or walk. Research shows structured recovery boosts working-memory scores—your Cat I secret weapon.
+
+
+Spring 2027 – Semester 4
+
+
+- Professional goal: 
+- Jan – Prepare 90-second “investment philosophy” script for partner interviews / final round interviews
+- Apr – Final deliverable: send polished IP2 research paper and published Arctos case to new employer
+- Academic goal:
+- School
+- Achieve Baker Scholar designation!
+- IP1
+- Jan – Complete teaching note
+- Feb – Submit final case and teaching note to HBSP by Feb 15 (joint)
+- Mar – Co-teach a segment on case (joint)
+- Apr – Submit reflection to faculty sponsor (joint) 
+- IP2
+- Jan – Register the research project during the add-drop period
+- Feb –  Begin 6-week writing sprint after IP1 HBSP submission
+- Apr – Complete paper draft by first week in April
+- Apr – Complete final paper by last week in April
+- Apr – Submit reflection to faculty sponsor
+- Tips: 
+- Professional
+- Show professionals that you’re wrestling with questions (“Why does permanent capital trade at X discount?”) rather than listing activities. In networking emails, always lead with an insight or hypothesis, not a request.
+- After an informational chat, send the contact a “reflection note” on what you learned and how it shapes your thesis. It positions you as a peer-thinker, not a supplicant.
+- Academic
+- 10 × I, 20 × II = 1.33 GPA -> 95% likelihood to earn Baker distinction 
+- Enlist professors in crusade to earn Baker Scholar recognition
+- Instead of 30-minute office-hour slots, drop professors a single, well-scoped question by email (takes them < 5 min to answer). Return with an update the next week. It compounds goodwill with near-zero time costs.
+- Write a 150-word distillation after every class. Turns each case into recall fodder before finals and primes you for Category I exam essays. Takes <10 min—small habit, big GPA delta.
+- Participation portfolio approach. Aim for two high-impact comments per class week. Track them in a spreadsheet (case, date, angle, outcome). Portfolio thinking avoids feast-or-famine comment weeks that jeopardize Cat I odds.
+- Protections:
+- Avoid club leadership. RC and EC grades are critical, and IPs already supply résumé substance.
+- Protect two 3-hour, early-morning “deep work sessions” (maybe early a.m. Tue / Fri). Never surrender them—IP writing, data work, or deep reading only.
+- Maintain a strict, 5-day workout regimen—essential for intellectual digestion, reflection, stress management, energy regulation, and self-esteem boosting.
+- Block Tuesdays 15:30-17:00 and Friday lunch for coffees. Anything outside these windows cannibalizes case prep—non-negotiable if you want 1.33 GPA.
+- 90-minute “velocity recovery” block every Sunday. 30 min reflection (WIRTW), 30 min planning, 30 min meditation or walk. Research shows structured recovery boosts working-memory scores—your Cat I secret weapon.


### PR DESCRIPTION
## Summary
- fix wording in `strategic_priorities.md`
- document now presents an academic and professional timeline from Summer 2025 through Spring 2027

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f4161fb30832685aa75551a6f07f1